### PR TITLE
Allow Ubuntu 22.04

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -115,7 +115,7 @@ USERDATA/%P                    mountpoint=/home/%P canmount=on com.ubuntu.zsys:b
 '
 c_zfs_mount_dir=/mnt
 c_installed_os_mount_dir=/target
-declare -A c_supported_linux_distributions=([Debian]="10 11" [Ubuntu]="18.04 20.04" [UbuntuServer]="18.04 20.04" [LinuxMint]="19.1 19.2 19.3" [Linuxmint]="20 20.1" [elementary]=5.1)
+declare -A c_supported_linux_distributions=([Debian]="10 11" [Ubuntu]="18.04 20.04 22.04" [UbuntuServer]="18.04 20.04 22.04" [LinuxMint]="19.1 19.2 19.3" [Linuxmint]="20 20.1" [elementary]=5.1)
 c_temporary_volume_size=12  # gigabytes; large enough - Debian, for example, takes ~8 GiB.
 c_passphrase_named_pipe=$(dirname "$(mktemp)")/zfs-installer.pp.fifo
 c_dns=8.8.8.8


### PR DESCRIPTION
Tested successfully with the latest Ubuntu Server 22.04 Beta, as of 2022-04-12. (VMware ESXi 7, 2x 32GB vdisks, 4GB installation partition in the guide)